### PR TITLE
optimized the reading and writing of our >100 million row tables

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KubernetesApiPersistence">{}</component>
   <component name="KubernetesApiProvider">{

--- a/docker/lakekeeper/docker-compose.yaml
+++ b/docker/lakekeeper/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       resources:
         limits:
           cpus: '10.0'  # Allow up to 10 CPU cores
-          memory: 48G
+          memory: 32G
         reservations:
           cpus: '4.0'
           memory: 8G
@@ -39,6 +39,14 @@ services:
       timeout: 10s
       retries: 3
       start_period: 3s
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'  # Allow up to 10 CPU cores
+          memory: 8G
+        reservations:
+          cpus: '2.0'
+          memory: 4G
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/docker/lakekeeper/notebooks/first_steps-iceberg.ipynb
+++ b/docker/lakekeeper/notebooks/first_steps-iceberg.ipynb
@@ -5,8 +5,8 @@
    "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-27T00:56:38.580971Z",
-     "start_time": "2025-09-27T00:56:38.360266Z"
+     "end_time": "2025-09-27T19:41:28.296177Z",
+     "start_time": "2025-09-27T19:41:28.060932Z"
     }
    },
    "outputs": [],
@@ -37,22 +37,31 @@
    "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-27T00:56:39.334239Z",
-     "start_time": "2025-09-27T00:56:39.331042Z"
+     "end_time": "2025-09-27T19:41:32.155148Z",
+     "start_time": "2025-09-27T19:41:32.148494Z"
     }
    },
    "outputs": [],
    "source": [
     "config = {\n",
-    "    f\"spark.sql.catalog.lakekeeper\": \"org.apache.iceberg.spark.SparkCatalog\",\n",
-    "    f\"spark.sql.catalog.lakekeeper.type\": \"rest\",\n",
-    "    f\"spark.sql.catalog.lakekeeper.uri\": CATALOG_URL,\n",
-    "    f\"spark.sql.catalog.lakekeeper.warehouse\": WAREHOUSE,\n",
-    "    f\"spark.sql.catalog.lakekeeper.io-impl\": \"org.apache.iceberg.aws.s3.S3FileIO\",\n",
+    "    \"spark.sql.catalog.lakekeeper\": \"org.apache.iceberg.spark.SparkCatalog\",\n",
+    "    \"spark.sql.catalog.lakekeeper.type\": \"rest\",\n",
+    "    \"spark.sql.catalog.lakekeeper.uri\": CATALOG_URL,\n",
+    "    \"spark.sql.catalog.lakekeeper.warehouse\": WAREHOUSE,\n",
+    "    \"spark.sql.catalog.lakekeeper.io-impl\": \"org.apache.iceberg.aws.s3.S3FileIO\",\n",
     "    \"spark.sql.extensions\": \"org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions\",\n",
     "    \"spark.sql.defaultCatalog\": \"lakekeeper\",\n",
-    "    \"spark.driver.memory\": \"16G\",\n",
-    "    \"spark.jars.packages\": f\"org.apache.iceberg:iceberg-spark-runtime-{SPARK_MINOR_VERSION}_2.13:{ICEBERG_VERSION},org.apache.iceberg:iceberg-aws-bundle:{ICEBERG_VERSION}\"\n",
+    "    \"spark.driver.memory\": \"24G\",\n",
+    "    \"spark.jars.packages\": f\"org.apache.iceberg:iceberg-spark-runtime-{SPARK_MINOR_VERSION}_2.13:{ICEBERG_VERSION},org.apache.iceberg:iceberg-aws-bundle:{ICEBERG_VERSION}\",\n",
+    "    # about zstd: Turn on zstd to make things highly compressed. Less size on disk, less IO bandwidth!\n",
+    "    # we want to use zstd for parquet: \n",
+    "    \"spark.sql.parquet.compression.codec\": \"zstd\",\n",
+    "    \"spark.sql.iceberg.planning.preserve-data-grouping\": \"true\",\n",
+    "    # we also want to use zstd for iceberg datafiles\n",
+    "    \"spark.sql.iceberg.compression-codec\": \"zstd\",\n",
+    "    \"spark.sql.iceberg.locality.enabled\": \"true\",\n",
+    "    # note: merge-schema should be only set to true if you \"trust\" the upstream data producer\n",
+    "    \"spark.sql.iceberg.merge-schema\": \"false\",\n",
     "}"
    ]
   },
@@ -61,23 +70,8 @@
    "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-27T00:56:41.197731Z",
-     "start_time": "2025-09-27T00:56:41.191420Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# spark.sql.shuffle.partitions (need to be smaller for streaming)\n",
-    "# looking at the output of the parquet dir"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:56:44.878251Z",
-     "start_time": "2025-09-27T00:56:42.241633Z"
+     "end_time": "2025-09-27T19:41:43.555148Z",
+     "start_time": "2025-09-27T19:41:35.492584Z"
     }
    },
    "outputs": [],
@@ -86,12 +80,36 @@
     "for k, v in config.items():\n",
     "    spark_config = spark_config.set(k, v)\n",
     "\n",
-    "spark = SparkSession.builder.config(conf=spark_config).getOrCreate()\n"
+    "spark: SparkSession = SparkSession.builder.config(conf=spark_config).getOrCreate()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:41:43.559214Z",
+     "start_time": "2025-09-27T19:41:43.555782Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# spark.sql.shuffle.partitions (need to be smaller for streaming)\n",
+    "# the default is 200, which is great for huge data, but bad for small incremental streams\n",
+    "# spark.conf.get('spark.sql.shuffle.partitions')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:41:44.279110Z",
+     "start_time": "2025-09-27T19:41:43.557788Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -104,45 +122,30 @@
    ],
    "source": [
     "spark.sql(\"USE lakekeeper\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:56:57.325246Z",
-     "start_time": "2025-09-27T00:56:56.548266Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-27T00:56:58.076495Z",
-     "start_time": "2025-09-27T00:56:58.040890Z"
+     "end_time": "2025-09-27T19:41:44.285024Z",
+     "start_time": "2025-09-27T19:41:44.278704Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "[('spark.jars',\n  'file:///home/jovyan/.ivy2.5.2/jars/org.apache.iceberg_iceberg-spark-runtime-4.0_2.13-1.10.0.jar,file:///home/jovyan/.ivy2.5.2/jars/org.apache.iceberg_iceberg-aws-bundle-1.10.0.jar'),\n ('spark.hadoop.fs.s3a.vectored.read.min.seek.size', '128K'),\n ('spark.executor.extraJavaOptions',\n  '-Djava.net.preferIPv6Addresses=false -XX:+IgnoreUnrecognizedVMOptions --add-modules=jdk.incubator.vector --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED -Djdk.reflect.useDirectMethodHandle=false -Dio.netty.tryReflectionSetAccessible=true'),\n ('spark.sql.artifact.isolation.enabled', 'false'),\n ('spark.sql.catalog.lakekeeper', 'org.apache.iceberg.spark.SparkCatalog'),\n ('spark.sql.extensions',\n  'org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions'),\n ('spark.driver.host', '5c0fa20271a2'),\n ('spark.master', 'local[*]'),\n ('spark.app.initial.jar.urls',\n  'spark://5c0fa20271a2:33389/jars/org.apache.iceberg_iceberg-spark-runtime-4.0_2.13-1.10.0.jar,spark://5c0fa20271a2:33389/jars/org.apache.iceberg_iceberg-aws-bundle-1.10.0.jar'),\n ('spark.repl.local.jars',\n  'file:///home/jovyan/.ivy2.5.2/jars/org.apache.iceberg_iceberg-spark-runtime-4.0_2.13-1.10.0.jar,file:///home/jovyan/.ivy2.5.2/jars/org.apache.iceberg_iceberg-aws-bundle-1.10.0.jar'),\n ('spark.app.startTime', '1758934603351'),\n ('spark.executor.id', 'driver'),\n ('spark.driver.port', '33389'),\n ('spark.app.initial.file.urls',\n  'file:///home/jovyan/.ivy2.5.2/jars/org.apache.iceberg_iceberg-spark-runtime-4.0_2.13-1.10.0.jar,file:///home/jovyan/.ivy2.5.2/jars/org.apache.iceberg_iceberg-aws-bundle-1.10.0.jar'),\n ('spark.driver.memory', '16G'),\n ('spark.submit.deployMode', 'client'),\n ('spark.serializer.objectStreamReset', '100'),\n ('spark.files',\n  'file:///home/jovyan/.ivy2.5.2/jars/org.apache.iceberg_iceberg-spark-runtime-4.0_2.13-1.10.0.jar,file:///home/jovyan/.ivy2.5.2/jars/org.apache.iceberg_iceberg-aws-bundle-1.10.0.jar'),\n ('spark.app.submitTime', '1758934603140'),\n ('spark.sql.warehouse.dir', 'file:/home/jovyan/spark-warehouse'),\n ('spark.ui.showConsoleProgress', 'true'),\n ('spark.rdd.compress', 'True'),\n ('spark.sql.catalog.lakekeeper.warehouse', 'demo'),\n ('spark.sql.defaultCatalog', 'lakekeeper'),\n ('spark.sql.catalog.lakekeeper.uri', 'http://lakekeeper:8181/catalog'),\n ('spark.jars.packages',\n  'org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.0,org.apache.iceberg:iceberg-aws-bundle:1.10.0'),\n ('spark.driver.extraJavaOptions',\n  '-Djava.net.preferIPv6Addresses=false -XX:+IgnoreUnrecognizedVMOptions --add-modules=jdk.incubator.vector --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED -Djdk.reflect.useDirectMethodHandle=false -Dio.netty.tryReflectionSetAccessible=true'),\n ('spark.hadoop.fs.s3a.vectored.read.max.merged.size', '2M'),\n ('spark.app.name', 'Iceberg-REST'),\n ('spark.submit.pyFiles',\n  '/home/jovyan/.ivy2.5.2/jars/org.apache.iceberg_iceberg-spark-runtime-4.0_2.13-1.10.0.jar,/home/jovyan/.ivy2.5.2/jars/org.apache.iceberg_iceberg-aws-bundle-1.10.0.jar'),\n ('spark.sql.catalog.lakekeeper.type', 'rest'),\n ('spark.sql.catalog.lakekeeper.io-impl',\n  'org.apache.iceberg.aws.s3.S3FileIO'),\n ('spark.app.id', 'local-1758934603665')]"
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "spark.sparkContext.getConf().getAll()"
+    "# uncomment the following to view the full SparkConf\n",
+    "# spark.sparkContext.getConf().getAll()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-27T00:56:59.189925Z",
-     "start_time": "2025-09-27T00:56:59.184131Z"
+     "end_time": "2025-09-27T19:07:15.747187Z",
+     "start_time": "2025-09-27T19:07:15.730897Z"
     }
    },
    "outputs": [
@@ -150,38 +153,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "reducing shuffle partitions to 64\n"
+      "reducing shuffle partitions to 32\n"
      ]
     }
    ],
    "source": [
     "if int(spark.conf.get(\"spark.sql.shuffle.partitions\")) > 100:\n",
-    "    print(\"reducing shuffle partitions to 64\")\n",
-    "    spark.conf.set(\"spark.sql.shuffle.partitions\", \"64\")"
+    "    print(\"reducing shuffle partitions to 32\")\n",
+    "    spark.conf.set(\"spark.sql.shuffle.partitions\", \"32\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:00.761116Z",
-     "start_time": "2025-09-27T00:57:00.755846Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# this is a favorite of mine. Turn on zstd to make things highly compressed. Less size on disk, less IO bandwidth!\n",
-    "spark.conf.set(\"spark.sql.parquet.compression.codec\", \"zstd\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:01.463125Z",
-     "start_time": "2025-09-27T00:57:01.456545Z"
+     "end_time": "2025-09-27T19:41:51.961289Z",
+     "start_time": "2025-09-27T19:41:51.955266Z"
     }
    },
    "outputs": [],
@@ -203,11 +191,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:02.951466Z",
-     "start_time": "2025-09-27T00:57:02.944817Z"
+     "end_time": "2025-09-27T19:41:52.699958Z",
+     "start_time": "2025-09-27T19:41:52.692512Z"
     }
    },
    "outputs": [],
@@ -218,50 +206,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "outputs": [],
-   "source": [
-    "ecomm_raw_dir = dataset_dir.joinpath('ecomm_raw')"
-   ],
+   "execution_count": 9,
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:03.413137Z",
-     "start_time": "2025-09-27T00:57:03.409206Z"
+     "end_time": "2025-09-27T19:41:53.284834Z",
+     "start_time": "2025-09-27T19:41:53.280348Z"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "ecomm_raw_dir = dataset_dir.joinpath('ecomm_raw')"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:41:53.665896Z",
+     "start_time": "2025-09-27T19:41:53.657942Z"
+    }
+   },
    "outputs": [],
    "source": [
     "october_data = (ecomm_raw_dir.joinpath(\"2019-Oct.csv\")).as_posix()\n",
     "november_data = (ecomm_raw_dir.joinpath(\"2019-Nov.csv\")).as_posix()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:03.778826Z",
-     "start_time": "2025-09-27T00:57:03.775622Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "## Create the E-commerce Data for ingestion to Iceberg\n",
     "> we'll be using the '2019-Oct.csv', '2019-Nov.csv' datasets, doing some minor tweaks and then using these to populate our base Iceberg tables\n",
     "> \n",
     "> Then we'll move on to doing Iceberg Streaming in Part 2"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:41:55.917432Z",
+     "start_time": "2025-09-27T19:41:55.786563Z"
+    }
+   },
    "outputs": [],
    "source": [
     "ecomm_oct_df = (\n",
@@ -270,18 +265,18 @@
     "    .schema(schema)\n",
     "    .load(october_data)\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:05.940351Z",
-     "start_time": "2025-09-27T00:57:05.811429Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:41:57.348974Z",
+     "start_time": "2025-09-27T19:41:56.696712Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -316,42 +311,42 @@
    ],
    "source": [
     "ecomm_oct_df.show()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:07.375623Z",
-     "start_time": "2025-09-27T00:57:06.745762Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:42:00.398013Z",
+     "start_time": "2025-09-27T19:41:58.099569Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": "42448764"
      },
-     "execution_count": 15,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "ecomm_oct_df.count()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:11.693305Z",
-     "start_time": "2025-09-27T00:57:09.247466Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:42:01.252814Z",
+     "start_time": "2025-09-27T19:42:01.228202Z"
+    }
+   },
    "outputs": [],
    "source": [
     "ecomm_nov_df = (\n",
@@ -360,18 +355,18 @@
     "    .schema(schema)\n",
     "    .load(november_data)\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:14.899639Z",
-     "start_time": "2025-09-27T00:57:14.874807Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:42:01.926598Z",
+     "start_time": "2025-09-27T19:42:01.861272Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -406,41 +401,37 @@
    ],
    "source": [
     "ecomm_nov_df.show()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:15.537057Z",
-     "start_time": "2025-09-27T00:57:15.460248Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:42:05.817767Z",
+     "start_time": "2025-09-27T19:42:02.767435Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": "67501979"
      },
-     "execution_count": 18,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "ecomm_nov_df.count()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:21.334627Z",
-     "start_time": "2025-09-27T00:57:18.130877Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "### Create the Initial Parquet Tables \n",
     "> These will live outside of MinIO and the Iceberg Catalog\n",
@@ -448,14 +439,18 @@
     "* We'll create a simple helper function to _aid_ in our journey. We'll call it `write_parquet`.\n",
     "* Using the new _function_, we'll then need to convert the **csv**->**parquet**, so run the **two** cells under \"convert the data\". They will produce raw parquet records under the path `datasets/ecomm_raw/parquet/ecomm`.\n",
     "* We will then be able to run a series of 'daily' transactions to **write** all of the records into our foundational **iceberg** table."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:42:07.660137Z",
+     "start_time": "2025-09-27T19:42:07.632118Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def write_parquet(df: DataFrame, destination: Path, sink_dir: str) -> DataFrame:\n",
@@ -476,37 +471,37 @@
     "            .save(save_path.as_posix())\n",
     "    )\n",
     "    "
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:52:50.860794Z",
-     "start_time": "2025-09-27T00:52:50.846383Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "### Convert the Data\n",
     "We're on a mission to convert CSV to Parquet. Let's do that next.\n",
     "> Note: This process may take a while if you're using the full dataset (~19GB)\n",
     "> Note: The function \"expects\" that we'll be _appending__ to the **ecomm** directory.\n",
     "> * If you want to modify the behavior of the function, give it a new argument called mode, and default that to \"errorIfExists\" of \"ignore\" - so you don't have to worry about deduplication or going nuculear and wiping out the entire ecomm directory!\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:42:12.616416Z",
+     "start_time": "2025-09-27T19:42:12.605303Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "oh good. Saved you from having to import again\n"
+      "oh good. Saved you from having to import again. Not to mention the duplicates - what a mess\n"
      ]
     }
    ],
@@ -519,25 +514,25 @@
     "if not ecomm_raw_dir.joinpath('parquet', 'ecomm', 'event_date=2019-10-01').is_dir():\n",
     "  write_parquet(ecomm_oct_df, ecomm_raw_dir, 'ecomm')\n",
     "else:\n",
-    "  print(\"oh good. Saved you from having to import again\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:52:56.711465Z",
-     "start_time": "2025-09-27T00:52:56.701705Z"
-    }
-   }
+    "  print(\"oh good. Saved you from having to import again. Not to mention the duplicates - what a mess\")"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:42:16.050048Z",
+     "start_time": "2025-09-27T19:42:16.044031Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "same goes for the november set. It exists, so we'll skip for now\n"
+      "same goes for the november set. It exists, so we'll skip for now.\n"
      ]
     }
    ],
@@ -545,32 +540,32 @@
     "if not ecomm_raw_dir.joinpath('parquet', 'ecomm', 'event_date=2019-11-01').is_dir():\n",
     "  write_parquet(ecomm_nov_df, ecomm_raw_dir, 'ecomm')\n",
     "else:\n",
-    "  print(\"same goes for the november set. It exists, so we'll skip for now\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:52:58.484193Z",
-     "start_time": "2025-09-27T00:52:58.478133Z"
-    }
-   }
+    "  print(\"same goes for the november set. It exists, so we'll skip for now.\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "## Iceberg: Creating and Appending data to Iceberg Tables\n",
     "> This section will help us build a firm understanding of how to work with Iceberg Tables\n",
     "1. Learn to easily check for table existence\n",
     "2. Learn to use Spark SQL to create Namespaces (this is where our tables live)\n",
     "3. Use the simple table existence check to either a) create a new Iceberg table, or b) append new rows to an existing table within a Namespace"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:42:18.339703Z",
+     "start_time": "2025-09-27T19:42:18.307566Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# let's identify a helper function to check to see if a \"table\" exists\n",
@@ -579,30 +574,30 @@
     "\n",
     "def table_exists(table_name: str):\n",
     "    return any(table.name == table_name for table in spark.catalog.listTables())"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:30.359966Z",
-     "start_time": "2025-09-27T00:57:30.344104Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "## Tables live in Namespaces\n",
     "Namespaces are a way of **grouping** tables together in the same way you would use **data domains** to separate different categories of data. \n",
     "> In practice, a namespace could be something like \"consumer\", \"product\", \"orders\" for ecommerce.\n",
     "> For our demo, we'll just call the namespace `icystreams` since we are grouping data to use for _Streaming Iceberg_"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:42:23.866275Z",
+     "start_time": "2025-09-27T19:42:23.732152Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -620,47 +615,22 @@
     "catalog_namespace = 'icystreams'\n",
     "spark.sql(f\"CREATE NAMESPACE IF NOT EXISTS {catalog_namespace}\")\n",
     "spark.sql(\"SHOW NAMESPACES\").show()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:32.629062Z",
-     "start_time": "2025-09-27T00:57:32.518352Z"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "'lakekeeper'"
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# The current catalog will be the value of the following configuration: spark.conf.get(\"spark.sql.defaultCatalog\")\n",
-    "spark.catalog.currentCatalog()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:35.085613Z",
-     "start_time": "2025-09-27T00:57:35.076635Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 22,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:42:32.514611Z",
+     "start_time": "2025-09-27T19:42:32.486475Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "[Database(name='icystreams', catalog='lakekeeper', description=None, locationUri='s3://examples/initial-warehouse/0199881f-dbaa-7841-9c60-cae98e839ecb')]"
+      "text/plain": "'lakekeeper'"
      },
      "execution_count": 22,
      "metadata": {},
@@ -668,24 +638,24 @@
     }
    ],
    "source": [
-    "# within the Apache Spark ecosystem. Our namespace is equivalent to a traditional hive \"database\", or Unity Catalog \"schema\"\n",
-    "spark.catalog.listDatabases()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:36.028141Z",
-     "start_time": "2025-09-27T00:57:35.889002Z"
-    }
-   }
+    "# The current catalog will be the value of the following configuration: spark.conf.get(\"spark.sql.defaultCatalog\")\n",
+    "spark.catalog.currentCatalog()"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 23,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:42:33.316550Z",
+     "start_time": "2025-09-27T19:42:33.173044Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "[Database(name='icystreams', catalog='lakekeeper', description=None, locationUri='s3://examples/initial-warehouse/0199881f-dbaa-7841-9c60-cae98e839ecb')]"
+      "text/plain": "[Database(name='icystreams', catalog='lakekeeper', description=None, locationUri='s3://examples/initial-warehouse/01998cb2-ac2e-7cb0-b341-ae5794445827')]"
      },
      "execution_count": 23,
      "metadata": {},
@@ -693,52 +663,64 @@
     }
    ],
    "source": [
+    "# within the Apache Spark ecosystem. Our namespace is equivalent to a traditional hive \"database\", or Unity Catalog \"schema\"\n",
     "spark.catalog.listDatabases()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:37.363701Z",
-     "start_time": "2025-09-27T00:57:37.298355Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "> Note: To simplify how we write to Iceberg, we are going to use the `spark.catalog.*` functions to point to `lakekeeper.icystreams`."
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "source": [
+    "> Note: To simplify how we write to Iceberg, we are going to use the `spark.catalog.*` functions to point to `lakekeeper.icystreams`."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 24,
-   "outputs": [],
-   "source": [
-    "spark.catalog.setCurrentDatabase('icystreams')"
-   ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:40.213671Z",
-     "start_time": "2025-09-27T00:57:40.202540Z"
+     "end_time": "2025-09-27T19:42:34.964545Z",
+     "start_time": "2025-09-27T19:42:34.953419Z"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "spark.catalog.setCurrentDatabase('icystreams')"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "spark.catalog.listTables()"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.catalog.listTables()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:42:57.867247Z",
+     "start_time": "2025-09-27T19:42:57.860574Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def write_iceberg(df: DataFrame, namespace: str, table_name: str, partition_col: str) -> DataFrame:\n",
@@ -752,81 +734,100 @@
     "    if table_exists(table_name):\n",
     "        return to_iceberg.append()\n",
     "    return to_iceberg.create()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-26T22:53:05.741377Z",
-     "start_time": "2025-09-26T22:53:05.735195Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "outputs": [],
-   "source": [
-    "# setting this outside of the context of the next **write_iceberg** block\n",
-    "# this lets us skip writing if we've already done so\n",
-    "iceberg_table_name = 'ecomm'"
-   ],
+   "execution_count": 71,
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:44.070315Z",
-     "start_time": "2025-09-27T00:57:44.062388Z"
+     "end_time": "2025-09-27T20:15:12.998260Z",
+     "start_time": "2025-09-27T20:15:12.956297Z"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "# provide a way of creating hidden partitions\n",
+    "# note: check out all the tableproperties here (https://iceberg.apache.org/docs/latest/configuration/)\n",
+    "def write_iceberg_hidden_partitions(df: DataFrame, namespace: str, table_name: str, partitioned_by_cols: str) -> DataFrame:\n",
+    "    \"\"\"\n",
+    "    This will create a new iceberg table (if it doesn't exist)\n",
+    "    :param df: The reference DataFrame to steal our schema from\n",
+    "    :param namespace: The namespace to write the table within\n",
+    "    :param table_name: The name of the table\n",
+    "    :param partitioned_by_cols: The PARTITIONED BY (clause). Example: 'days(event_time), category_id'\n",
+    "    :return: an empty DataFrame on success\n",
+    "    \"\"\"\n",
+    "    # todo - add default ordering : ORDERED BY (category ASC, event_time DESC)\n",
+    "    if not table_exists(table_name):\n",
+    "        # fetch the ddl from the dataframe schema\n",
+    "        table_ddl = df.schema.toDDL()\n",
+    "        res_df = spark.sql(f\"\"\"\n",
+    "            CREATE TABLE IF NOT EXISTS {namespace}.{table_name} (\n",
+    "                {table_ddl}\n",
+    "            ) USING ICEBERG\n",
+    "            PARTITIONED BY ({partitioned_by_cols})\n",
+    "            TBLPROPERTIES(\n",
+    "            'read.split.planning-lookback'='5',\n",
+    "            'read.parquet.vectorization.batch-size'='32'\n",
+    "            );\n",
+    "        \"\"\")\n",
+    "        print(res_df.show())\n",
+    "    \n",
+    "    # since we explicitly create the table, we can simplify this vs the other version of the function\n",
+    "    return df.writeTo(f\"{namespace}.{table_name}\").append()\n",
+    "    "
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Writing our Parquet into Iceberg\n",
-    "The following cell needs to be re-run for every day of October and November 2019.\n",
-    "\n",
-    "You can choose to group many days into single transactions\n",
-    "```python\n",
-    "(spark\n",
-    "    .read\n",
-    "    .format('parquet')\n",
-    "    .load(parquet_dir.as_posix())\n",
-    "    .where(\n",
-    "        col(\"event_date\").isin(\n",
-    "            \"2019-10-01\", \"2019-10-02\", \"2019-10-03\", \"2019-10-04\"\n",
-    "        )\n",
-    "    )\n",
-    ")\n",
-    "```\n",
-    "\n",
-    "Maybe you want to regroup the data by hour and test creating 24 transactions per day across all days. Really, the world is your oyster!\n"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "source": [
+    "## Writing our Parquet into Iceberg\n",
+    "The following two cells will copy all data from the October and November 2019 parquet records\n",
+    "into the Iceberg tables `ecomm` and `ecomm_hidden`. \n",
+    "\n",
+    "The big difference here is that we don't need to \"add\" additional columns to the source parquet to this functionality.\n",
+    "> Note: If you are familiar with generated columns (generateAlwaysAs), then think of the PARTITIONED BY(days(event_time), bucket(8, category_id)) \n",
+    "> as the same kind of mechanic. Remember, you can always change your mind later and drop or add additional partitoning without\n",
+    "> rewriting the entire table. Enjoy.\n"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 73,
    "outputs": [],
    "source": [
     "# set the reference to the parquet directory\n",
-    "parquet_dir = ecomm_raw_dir.joinpath('parquet', 'ecomm')"
+    "parquet_dir = ecomm_raw_dir.joinpath('parquet', 'ecomm')\n",
+    "iceberg_table_name = 'ecomm'\n",
+    "iceberg_table_name_hp = \"ecomm_hidden\""
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:48.291139Z",
-     "start_time": "2025-09-27T00:57:48.286415Z"
+     "end_time": "2025-09-27T20:16:06.004139Z",
+     "start_time": "2025-09-27T20:16:05.989895Z"
     }
    }
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 54,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T19:59:01.982687Z",
+     "start_time": "2025-09-27T19:56:55.767438Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Run the following block to write a single transaction per day\n",
-    "# Note: This took around 4 minutes on a high-powered M3 Ultra computer - non-clustered (eg: spark.master=local[*])\n",
+    "# Note: This took around 2 minutes on a high-powered M3 Ultra computer - 10 core (eg: spark.master=local[*])\n",
     "# This can run on a single machine really easily - but blindingly fast in a cluster (only latency is IO between your object storage and your Iceberg Rest Catalog API and the Spark Cluster)\n",
     "year = \"2019\"\n",
     "months = ['10', '11']\n",
@@ -844,23 +845,524 @@
     "        iceberg_table_name,\n",
     "        'event_date'\n",
     "        )\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------+\n",
+      "|    total|\n",
+      "+---------+\n",
+      "|109950743|\n",
+      "+---------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "spark.sql(f\"select count(*) as total from {catalog_namespace}.{iceberg_table_name}\").show()"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2025-09-26T23:08:57.635255Z",
-     "start_time": "2025-09-26T23:04:41.653770Z"
+     "end_time": "2025-09-27T20:01:15.954295Z",
+     "start_time": "2025-09-27T20:01:15.833143Z"
     }
    }
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 60,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----------+-----+-------------------+-------------------+\n",
+      "|product_id|total|           min_time|           max_time|\n",
+      "+----------+-----+-------------------+-------------------+\n",
+      "|  17302664| 2573|2019-10-01 18:00:17|2019-11-12 15:48:40|\n",
+      "|   1003461| 3911|2019-10-01 18:07:04|2019-11-12 15:56:11|\n",
+      "+----------+-----+-------------------+-------------------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "# shows a query that can do mix/max pushdown with simple partition by on 'event_date'\n",
+    "spark.sql(f\"\"\"\n",
+    "select\n",
+    "  product_id, \n",
+    "  count(*) as total,\n",
+    "  min(event_time) as min_time, \n",
+    "  max(event_time) as max_time \n",
+    "  from {catalog_namespace}.{iceberg_table_name}\n",
+    "  where product_id in (17302664, 1003461) \n",
+    "  and event_time BETWEEN TIMESTAMP('2019-10-01 18:00:00') and TIMESTAMP('2019-11-12 16:00:00') \n",
+    "  group by product_id\n",
+    "\"\"\").show()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:04:16.585614Z",
+     "start_time": "2025-09-27T20:04:15.741951Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# writing all the same data just with hidden partitioning\n",
+    "# note: there are only 691 categories, while we have over 200k unique product identifiers\n",
+    "# bucketing by product_id is another strategy to reduce the directory cost with hidden partitions\n",
+    "# try some things, break some things, it is fine :)\n",
+    "use_ddl_table = \"ecomm_hidden_other\"\n",
+    "year = \"2019\"\n",
+    "months = ['10', '11']\n",
+    "for month in list(months):\n",
+    "    for day in (range(1, 32)) if month == '10' else (range(1, 31)):\n",
+    "        insert_date = f\"{year}-{month}-0{day}\" if day < 10 else f\"{year}-{month}-{day}\"\n",
+    "        write_iceberg_hidden_partitions(\n",
+    "            df=(\n",
+    "                spark.read\n",
+    "                .format('parquet')\n",
+    "                .load(parquet_dir.as_posix())\n",
+    "                .where(col(\"event_date\").isin(insert_date))\n",
+    "                .drop(col(\"event_date\"))\n",
+    "            ),\n",
+    "            namespace=catalog_namespace,\n",
+    "            table_name=use_ddl_table,\n",
+    "            partitioned_by_cols='days(event_time), bucket(8, category_id)'\n",
+    "        )"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-------------------+----------+----------+-------------------+--------------------+------------+-------+---------+--------------------+\n",
+      "|         event_time|event_type|product_id|        category_id|       category_code|       brand|  price|  user_id|        user_session|\n",
+      "+-------------------+----------+----------+-------------------+--------------------+------------+-------+---------+--------------------+\n",
+      "|2019-10-20 12:51:37|      view|  15200217|2053013553484398879|                NULL|        NULL| 123.56|545081263|c2e016df-d267-4cf...|\n",
+      "|2019-10-20 12:51:38|      view|   1801881|2053013554415534427|electronics.video.tv|     samsung| 493.93|514802508|ab915d15-8aae-49e...|\n",
+      "|2019-10-20 12:51:38|      view|   5801039|2053013553945772349|electronics.audio...|       hertz| 132.64|542448535|98dc10fa-427f-45f...|\n",
+      "|2019-10-20 12:51:38|  purchase|   5100742|2053013553341792533|  electronics.clocks|       honor| 148.01|517816925|6cba4ff0-0b07-4d8...|\n",
+      "|2019-10-20 12:51:39|      view|   1802064|2053013554415534427|electronics.video.tv|     philips| 566.27|551443583|eba53a23-34ec-456...|\n",
+      "|2019-10-20 12:51:39|      view|   1801830|2053013554415534427|electronics.video.tv|       yasin| 158.05|562241117|773b9116-15bd-41a...|\n",
+      "|2019-10-20 12:51:39|      view|   1801696|2053013554415534427|electronics.video.tv|     hisense| 772.19|514563875|24fd6e74-8cb7-47c...|\n",
+      "|2019-10-20 12:51:39|      view|  23200391|2053013562359546659|                NULL|coopervision|  21.88|513368418|2de35e84-469c-479...|\n",
+      "|2019-10-20 12:51:40|      view|   7600132|2053013552821698803|                NULL|     tp-link|  20.05|512964081|f213b8e7-5869-47f...|\n",
+      "|2019-10-20 12:51:40|      view|   1801691|2053013554415534427|electronics.video.tv|     samsung| 475.82|562246044|386818ac-050d-43e...|\n",
+      "|2019-10-20 12:51:40|      view|   5100338|2053013553341792533|  electronics.clocks|       apple| 334.11|552393607|826ae7c8-4df1-44f...|\n",
+      "|2019-10-20 12:51:41|      view|   1801513|2053013554415534427|electronics.video.tv|       haier| 489.05|525015316|1a4c7384-7550-469...|\n",
+      "|2019-10-20 12:51:41|      view|   1801929|2053013554415534427|electronics.video.tv|     samsung| 559.96|515370141|fc142478-427b-4ab...|\n",
+      "|2019-10-20 12:51:41|      view|   5301045|2053013563173241677|                NULL|      galaxy|   9.24|518645141|2b270c0e-5df9-4de...|\n",
+      "|2019-10-20 12:51:41|      view|  15200281|2053013553484398879|                NULL|        akom|  64.35|555016901|d58d4024-55d3-41f...|\n",
+      "|2019-10-20 12:51:42|      view|   1801854|2053013554415534427|electronics.video.tv|     samsung|1003.58|540466469|498e5623-8778-451...|\n",
+      "|2019-10-20 12:51:42|      view|   5801483|2053013553945772349|electronics.audio...|     pioneer|  58.95|562245399|b74ccaff-8afc-46d...|\n",
+      "|2019-10-20 12:51:42|      view|   1701505|2053013553031414015|computers.periphe...|     huntkey| 172.72|525684135|bb580390-1926-439...|\n",
+      "|2019-10-20 12:51:43|      view|  46300025|2110937218225800069|       apparel.dress|     aivengo|  34.22|514445420|37b12322-0f3e-411...|\n",
+      "|2019-10-20 12:51:43|      view|   2501143|2053013564003713919|appliances.kitche...|       artel|  36.01|535893988|f1ed7c2f-7789-4cb...|\n",
+      "+-------------------+----------+----------+-------------------+--------------------+------------+-------+---------+--------------------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "hidden_parts_df = spark.sql(f\"select * from {catalog_namespace}.{use_ddl_table}\")\n",
+    "hidden_parts_df.show()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:19:22.966622Z",
+     "start_time": "2025-09-27T20:19:22.783781Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----------+-----+-------------------+-------------------+\n",
+      "|product_id|total|           min_time|           max_time|\n",
+      "+----------+-----+-------------------+-------------------+\n",
+      "|  49500003| 2054|2019-10-02 17:08:09|2019-11-01 18:21:43|\n",
+      "|  13200834| 9778|2019-10-01 18:21:21|2019-11-12 15:59:27|\n",
+      "|  49300028|  217|2019-10-02 00:51:05|2019-10-28 16:02:04|\n",
+      "|  17800204| 3519|2019-10-01 18:54:18|2019-11-12 15:57:24|\n",
+      "|   2700658|  452|2019-10-02 09:12:59|2019-11-12 15:08:43|\n",
+      "|  11500291| 1183|2019-10-01 18:19:03|2019-11-12 15:57:30|\n",
+      "|  13201247|  277|2019-10-02 06:06:14|2019-11-12 10:49:36|\n",
+      "|   2702332| 3362|2019-10-01 18:19:38|2019-11-12 15:58:09|\n",
+      "|   9100019|  285|2019-10-01 20:06:03|2019-11-12 15:33:22|\n",
+      "|   9101528|  174|2019-10-02 06:22:15|2019-11-12 05:55:10|\n",
+      "|  35108841|   13|2019-10-07 12:57:28|2019-11-08 14:50:27|\n",
+      "|  11500489|  170|2019-10-01 18:11:57|2019-11-12 06:34:15|\n",
+      "|   1600437|  228|2019-10-02 03:38:48|2019-11-12 08:23:19|\n",
+      "|   6100213|  208|2019-10-02 10:42:16|2019-11-12 14:49:28|\n",
+      "|  13200148|  352|2019-10-02 08:34:35|2019-11-12 15:21:48|\n",
+      "|  34800380|   92|2019-10-08 17:02:34|2019-11-12 15:59:59|\n",
+      "|   2700779|  585|2019-10-02 03:30:34|2019-11-12 10:07:45|\n",
+      "|  19700152|   40|2019-10-05 17:08:31|2019-11-12 13:29:39|\n",
+      "|   1600635|  159|2019-10-08 03:56:04|2019-11-12 12:42:28|\n",
+      "|  17800052|  245|2019-10-01 18:22:10|2019-11-12 15:45:25|\n",
+      "+----------+-----+-------------------+-------------------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "spark.sql(f\"\"\"\n",
+    "select\n",
+    "  product_id, \n",
+    "  count(*) as total,\n",
+    "  min(event_time) as min_time, \n",
+    "  max(event_time) as max_time \n",
+    "  from {catalog_namespace}.{use_ddl_table}\n",
+    "  where product_id not in (17302664, 1003461)\n",
+    "  and event_time BETWEEN TIMESTAMP('2019-10-01 18:00:00') and TIMESTAMP('2019-11-12 16:00:00') \n",
+    "  group by product_id\n",
+    "\"\"\").show()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:20:00.795273Z",
+     "start_time": "2025-09-27T20:19:57.389293Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-RECORD 0-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      " createtab_stmt | CREATE TABLE lakekeeper.icystreams.ecomm_hidden_other (\\n  event_time TIMESTAMP,\\n  event_type STRING,\\n  product_id INT,\\n  category_id BIGINT,\\n  category_code STRING,\\n  brand STRING,\\n  price FLOAT,\\n  user_id INT,\\n  user_session STRING)\\nUSING iceberg\\nPARTITIONED BY (days(event_time))\\nCLUSTERED BY (category_id)\\nINTO 8 BUCKETS\\nLOCATION 's3://examples/initial-warehouse/01998cb2-ac2e-7cb0-b341-ae5794445827/01998cd3-0af8-7be3-a93a-28f07bb9d4ca'\\nTBLPROPERTIES (\\n  'current-snapshot-id' = '6151459368212957826',\\n  'format' = 'iceberg/parquet',\\n  'format-version' = '2',\\n  'read.parquet.vectorization.batch-size' = '32',\\n  'read.split.planning-lookback' = '5')\\n \n"
+     ]
+    }
+   ],
+   "source": [
+    "spark.sql(f\"show create table {catalog_namespace}.{use_ddl_table}\").show(100, 0, True)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:22:01.150677Z",
+     "start_time": "2025-09-27T20:22:01.079197Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------+\n",
+      "|    total|\n",
+      "+---------+\n",
+      "|109950743|\n",
+      "+---------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "spark.sql(f\"select count(*) as total from {catalog_namespace}.{iceberg_table_name_hp}\").show()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:01:11.079115Z",
+     "start_time": "2025-09-27T20:01:10.960085Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
    "outputs": [
     {
      "data": {
-      "text/plain": "       total\n0  109950743",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>total</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>109950743</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/plain": "             category_id\n0    2060237588744111062\n1    2090971686529663114\n2    2053013564003713919\n3    2053013556344914381\n4    2152167773222993940\n..                   ...\n686  2100064855133258156\n687  2053013560111399597\n688  2053013552259662037\n689  2055156924273394455\n690  2187707857414128194\n\n[691 rows x 1 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>category_id</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2060237588744111062</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2090971686529663114</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2053013564003713919</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2053013556344914381</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2152167773222993940</td>\n    </tr>\n    <tr>\n      <th>...</th>\n      <td>...</td>\n    </tr>\n    <tr>\n      <th>686</th>\n      <td>2100064855133258156</td>\n    </tr>\n    <tr>\n      <th>687</th>\n      <td>2053013560111399597</td>\n    </tr>\n    <tr>\n      <th>688</th>\n      <td>2053013552259662037</td>\n    </tr>\n    <tr>\n      <th>689</th>\n      <td>2055156924273394455</td>\n    </tr>\n    <tr>\n      <th>690</th>\n      <td>2187707857414128194</td>\n    </tr>\n  </tbody>\n</table>\n<p>691 rows × 1 columns</p>\n</div>"
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spark.sql(f\"select distinct(category_id) as category_id from {catalog_namespace}.{iceberg_table_name_hp}\").toPandas()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:11:44.236345Z",
+     "start_time": "2025-09-27T20:11:40.893449Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------------------+\n",
+      "|unique_product_ids|\n",
+      "+------------------+\n",
+      "|            206876|\n",
+      "+------------------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Note: we've got 206,876 unique product ids. This would be a bad column to partition on\n",
+    "spark.sql(f\"select count(distinct(product_id)) as unique_product_ids from {catalog_namespace}.{iceberg_table_name_hp}\").show()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:08:13.969322Z",
+     "start_time": "2025-09-27T20:08:10.396858Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-------------------+\n",
+      "|unique_category_ids|\n",
+      "+-------------------+\n",
+      "|                691|\n",
+      "+-------------------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Note: the cardinality of the category id's is only 691 distinct\n",
+    "spark.sql(f\"select count(distinct(category_id)) as unique_category_ids from {catalog_namespace}.{iceberg_table_name_hp}\").show()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:08:39.255691Z",
+     "start_time": "2025-09-27T20:08:36.124342Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "        product_id\n0         28300055\n1          1307545\n2         38900025\n3          5500325\n4          4900373\n...            ...\n206871   100025269\n206872    26006635\n206873    24300264\n206874    10800003\n206875    26600968\n\n[206876 rows x 1 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>product_id</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>28300055</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1307545</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>38900025</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>5500325</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>4900373</td>\n    </tr>\n    <tr>\n      <th>...</th>\n      <td>...</td>\n    </tr>\n    <tr>\n      <th>206871</th>\n      <td>100025269</td>\n    </tr>\n    <tr>\n      <th>206872</th>\n      <td>26006635</td>\n    </tr>\n    <tr>\n      <th>206873</th>\n      <td>24300264</td>\n    </tr>\n    <tr>\n      <th>206874</th>\n      <td>10800003</td>\n    </tr>\n    <tr>\n      <th>206875</th>\n      <td>26600968</td>\n    </tr>\n  </tbody>\n</table>\n<p>206876 rows × 1 columns</p>\n</div>"
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spark.sql(f\"select distinct(product_id) as product_id from {catalog_namespace}.{iceberg_table_name_hp}\").toPandas()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:12:24.410896Z",
+     "start_time": "2025-09-27T20:12:20.504896Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----------+-----+-------------------+-------------------+\n",
+      "|product_id|total|           min_time|           max_time|\n",
+      "+----------+-----+-------------------+-------------------+\n",
+      "|  28715821|  777|2019-10-02 06:59:28|2019-11-12 06:09:49|\n",
+      "|  28706430| 2589|2019-10-02 00:35:31|2019-11-03 15:06:39|\n",
+      "|  15600022| 1089|2019-10-01 18:18:07|2019-11-12 14:02:58|\n",
+      "|  26600154|  148|2019-10-02 12:51:58|2019-11-12 15:36:18|\n",
+      "|   4300425|  109|2019-10-02 06:36:54|2019-11-12 13:07:04|\n",
+      "|  28703068|   76|2019-10-12 01:43:51|2019-11-12 15:30:56|\n",
+      "|  47000059|  455|2019-10-04 05:54:34|2019-11-12 15:19:28|\n",
+      "|  30000077|  758|2019-10-01 23:12:23|2019-11-12 14:48:08|\n",
+      "|  22200112|  173|2019-10-01 19:52:42|2019-11-12 12:11:30|\n",
+      "|  52900142|  182|2019-10-10 02:51:48|2019-11-12 15:28:07|\n",
+      "|  45600191|  267|2019-10-16 11:24:10|2019-11-10 15:19:18|\n",
+      "|   4300232|  158|2019-10-09 13:53:21|2019-11-01 05:46:16|\n",
+      "|   1480506| 1477|2019-10-01 18:10:39|2019-11-12 03:55:18|\n",
+      "|  17100091|   89|2019-10-01 18:08:59|2019-11-12 11:27:18|\n",
+      "|   1480743| 1258|2019-10-03 05:18:59|2019-11-12 15:50:35|\n",
+      "|  28721421|  143|2019-10-18 06:29:50|2019-11-12 15:09:24|\n",
+      "|  15900439|   42|2019-10-05 05:56:57|2019-11-05 02:28:27|\n",
+      "|  39800101|   15|2019-10-03 20:35:43|2019-11-04 10:53:22|\n",
+      "|  43900084|   91|2019-10-07 09:20:41|2019-11-12 07:14:43|\n",
+      "|  26600131|  185|2019-10-03 15:50:55|2019-11-12 15:41:23|\n",
+      "+----------+-----+-------------------+-------------------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "# shows a query that can do mix/max pushdown and leans into the hidden date partitions to do file skipping\n",
+    "# you'll notice that we can do arbitrary filtering by hour as well.\n",
+    "# this query isn't taking advantage of category filtering (see how the two tables compare as homework)\n",
+    "spark.sql(f\"\"\"\n",
+    "select\n",
+    "  product_id, \n",
+    "  count(*) as total,\n",
+    "  min(event_time) as min_time, \n",
+    "  max(event_time) as max_time \n",
+    "  from {catalog_namespace}.{iceberg_table_name_hp}\n",
+    "  where product_id not in (17302664, 1003461)\n",
+    "  and event_time BETWEEN TIMESTAMP('2019-10-01 18:00:00') and TIMESTAMP('2019-11-12 16:00:00') \n",
+    "  group by product_id\n",
+    "\"\"\").show()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:27:40.450714Z",
+     "start_time": "2025-09-27T20:27:37.121169Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:13:57.315254Z",
+     "start_time": "2025-09-27T20:13:57.284541Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "                                      createtab_stmt\n0  CREATE TABLE lakekeeper.icystreams.ecomm (\\n  ...",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>createtab_stmt</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>CREATE TABLE lakekeeper.icystreams.ecomm (\\n  ...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# view the create table statement\n",
+    "spark.sql(f\"show create table {catalog_namespace}.{iceberg_table_name}\").toPandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:13:37.656740Z",
+     "start_time": "2025-09-27T20:13:37.601122Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "                        col_name  \\\n0                     event_time   \n1                     event_type   \n2                     product_id   \n3                    category_id   \n4                  category_code   \n5                          brand   \n6                          price   \n7                        user_id   \n8                   user_session   \n9                     event_date   \n10       # Partition Information   \n11                    # col_name   \n12                    event_date   \n13                                 \n14            # Metadata Columns   \n15                      _spec_id   \n16                    _partition   \n17                         _file   \n18                          _pos   \n19                      _deleted   \n20                                 \n21  # Detailed Table Information   \n22                          Name   \n23                          Type   \n24                      Location   \n25                      Provider   \n26                         Owner   \n27              Table Properties   \n28                    Statistics   \n\n                                            data_type  comment  \n0                                           timestamp     None  \n1                                              string     None  \n2                                                 int     None  \n3                                              bigint     None  \n4                                              string     None  \n5                                              string     None  \n6                                               float     None  \n7                                                 int     None  \n8                                              string     None  \n9                                                date     None  \n10                                                              \n11                                          data_type  comment  \n12                                               date     None  \n13                                                              \n14                                                              \n15                                                int           \n16                            struct<event_date:date>           \n17                                             string           \n18                                             bigint           \n19                                            boolean           \n20                                                              \n21                                                              \n22                        lakekeeper.icystreams.ecomm           \n23                                            MANAGED           \n24  s3://examples/initial-warehouse/01998cb2-ac2e-...           \n25                                            iceberg           \n26                                             jovyan           \n27  [current-snapshot-id=3591208576167435970,forma...           \n28                  12314483216 bytes, 109950743 rows     None  ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>col_name</th>\n      <th>data_type</th>\n      <th>comment</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>event_time</td>\n      <td>timestamp</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>event_type</td>\n      <td>string</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>product_id</td>\n      <td>int</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>category_id</td>\n      <td>bigint</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>category_code</td>\n      <td>string</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>brand</td>\n      <td>string</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>price</td>\n      <td>float</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>user_id</td>\n      <td>int</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>user_session</td>\n      <td>string</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>event_date</td>\n      <td>date</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td># Partition Information</td>\n      <td></td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td># col_name</td>\n      <td>data_type</td>\n      <td>comment</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>event_date</td>\n      <td>date</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td></td>\n      <td></td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td># Metadata Columns</td>\n      <td></td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>_spec_id</td>\n      <td>int</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>_partition</td>\n      <td>struct&lt;event_date:date&gt;</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>17</th>\n      <td>_file</td>\n      <td>string</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>18</th>\n      <td>_pos</td>\n      <td>bigint</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>19</th>\n      <td>_deleted</td>\n      <td>boolean</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>20</th>\n      <td></td>\n      <td></td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>21</th>\n      <td># Detailed Table Information</td>\n      <td></td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>22</th>\n      <td>Name</td>\n      <td>lakekeeper.icystreams.ecomm</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>23</th>\n      <td>Type</td>\n      <td>MANAGED</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>24</th>\n      <td>Location</td>\n      <td>s3://examples/initial-warehouse/01998cb2-ac2e-...</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>25</th>\n      <td>Provider</td>\n      <td>iceberg</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>26</th>\n      <td>Owner</td>\n      <td>jovyan</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>27</th>\n      <td>Table Properties</td>\n      <td>[current-snapshot-id=3591208576167435970,forma...</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>28</th>\n      <td>Statistics</td>\n      <td>12314483216 bytes, 109950743 rows</td>\n      <td>None</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spark.sql(f\"describe extended {catalog_namespace}.{iceberg_table_name}\").toPandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-09-27T00:57:55.189719Z",
+     "start_time": "2025-09-27T00:57:54.349194Z"
+    },
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>total</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>109950743</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       total\n",
+       "0  109950743"
+      ]
      },
      "execution_count": 27,
      "metadata": {},
@@ -869,31 +1371,24 @@
    ],
    "source": [
     "spark.sql(f\"select count(*) as total from {catalog_namespace}.{iceberg_table_name}\").toPandas()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:57:55.189719Z",
-     "start_time": "2025-09-27T00:57:54.349194Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 78,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-27T00:58:15.226141Z",
-     "start_time": "2025-09-27T00:58:13.033303Z"
+     "end_time": "2025-09-27T20:20:32.423543Z",
+     "start_time": "2025-09-27T20:20:30.347787Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "            event_time event_type  product_id          category_id  \\\n0  2019-11-30 09:44:10       view     1004158  2053013555631882655   \n1  2019-11-30 09:44:10       cart    17300768  2053013553853497655   \n2  2019-11-30 09:44:10       view    12703494  2053013553559896355   \n3  2019-11-30 09:44:10       view     5300252  2053013563173241677   \n4  2019-11-30 09:44:10       view     1002544  2053013555631882655   \n5  2019-11-30 09:44:10       view     1004833  2053013555631882655   \n6  2019-11-30 09:44:10       view     1004743  2053013555631882655   \n7  2019-11-30 09:44:10       cart     1005100  2053013555631882655   \n8  2019-11-30 09:44:10   purchase    12500508  2053013556277805513   \n9  2019-11-30 09:44:10       view    18000951  2053013558525952589   \n10 2019-11-30 09:44:10       view    12702956  2053013553559896355   \n11 2019-11-30 09:44:10       view     1004833  2053013555631882655   \n12 2019-11-30 09:44:10       view    32900155  2055156924407612189   \n13 2019-11-30 09:44:10       view     1307541  2053013558920217191   \n14 2019-11-30 09:44:10       view     1480682  2053013561092866779   \n\n             category_code     brand       price    user_id  \\\n0   electronics.smartphone   samsung  682.130005  575219697   \n1                     None      None   63.750000  519636344   \n2                     None  cordiant   41.189999  515671054   \n3                     None   polaris   25.709999  579548460   \n4   electronics.smartphone     apple  460.500000  513983510   \n5   electronics.smartphone   samsung  167.029999  573759994   \n6   electronics.smartphone    xiaomi   72.050003  516587653   \n7   electronics.smartphone   samsung  131.770004  552718105   \n8                     None      None   37.040001  514037703   \n9                     None   samsung    6.500000  514704543   \n10                    None    nokian   49.939999  538077530   \n11  electronics.smartphone   samsung  167.029999  514872316   \n12         accessories.bag    helios   21.350000  512715261   \n13      computers.notebook      asus  489.359985  531477761   \n14       computers.desktop      acer  371.440002  559512811   \n\n                            user_session  event_date  \n0   d5a319f8-aca2-412c-a797-8e78ba09159f  2019-11-30  \n1   34466b6b-aa50-4571-b327-bcbc015d652e  2019-11-30  \n2   382a1e92-e118-4efb-aa4a-adeafd1d3936  2019-11-30  \n3   2f88f349-f84d-4d1d-bd44-79f7dcb35b7f  2019-11-30  \n4   69ba2f17-993f-4ddf-899d-41d09d1ecd98  2019-11-30  \n5   170b6cd3-8554-45bd-9f74-afd844d6c0bb  2019-11-30  \n6   da277c8c-6b18-4dfe-8bb4-1217ad6b90f1  2019-11-30  \n7   3f781d61-4880-49b6-87f1-c76b8a672781  2019-11-30  \n8   03838da1-e669-4ddd-929f-80ed83f7655c  2019-11-30  \n9   62f805df-084f-4495-96e5-b19b30383f7b  2019-11-30  \n10  fc34faf4-5d7b-4619-956e-da5cb363d2f5  2019-11-30  \n11  f98319cb-150a-4881-9f75-225efc35f283  2019-11-30  \n12  8513665f-e4d5-41aa-9874-eb81a75246e0  2019-11-30  \n13  d531ac89-dbb0-4456-9fef-dde007e3fa55  2019-11-30  \n14  c04dbd7f-99d7-4244-9beb-b5d5a4af7e32  2019-11-30  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>event_time</th>\n      <th>event_type</th>\n      <th>product_id</th>\n      <th>category_id</th>\n      <th>category_code</th>\n      <th>brand</th>\n      <th>price</th>\n      <th>user_id</th>\n      <th>user_session</th>\n      <th>event_date</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>view</td>\n      <td>1004158</td>\n      <td>2053013555631882655</td>\n      <td>electronics.smartphone</td>\n      <td>samsung</td>\n      <td>682.130005</td>\n      <td>575219697</td>\n      <td>d5a319f8-aca2-412c-a797-8e78ba09159f</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>cart</td>\n      <td>17300768</td>\n      <td>2053013553853497655</td>\n      <td>None</td>\n      <td>None</td>\n      <td>63.750000</td>\n      <td>519636344</td>\n      <td>34466b6b-aa50-4571-b327-bcbc015d652e</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>view</td>\n      <td>12703494</td>\n      <td>2053013553559896355</td>\n      <td>None</td>\n      <td>cordiant</td>\n      <td>41.189999</td>\n      <td>515671054</td>\n      <td>382a1e92-e118-4efb-aa4a-adeafd1d3936</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>view</td>\n      <td>5300252</td>\n      <td>2053013563173241677</td>\n      <td>None</td>\n      <td>polaris</td>\n      <td>25.709999</td>\n      <td>579548460</td>\n      <td>2f88f349-f84d-4d1d-bd44-79f7dcb35b7f</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>view</td>\n      <td>1002544</td>\n      <td>2053013555631882655</td>\n      <td>electronics.smartphone</td>\n      <td>apple</td>\n      <td>460.500000</td>\n      <td>513983510</td>\n      <td>69ba2f17-993f-4ddf-899d-41d09d1ecd98</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>view</td>\n      <td>1004833</td>\n      <td>2053013555631882655</td>\n      <td>electronics.smartphone</td>\n      <td>samsung</td>\n      <td>167.029999</td>\n      <td>573759994</td>\n      <td>170b6cd3-8554-45bd-9f74-afd844d6c0bb</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>view</td>\n      <td>1004743</td>\n      <td>2053013555631882655</td>\n      <td>electronics.smartphone</td>\n      <td>xiaomi</td>\n      <td>72.050003</td>\n      <td>516587653</td>\n      <td>da277c8c-6b18-4dfe-8bb4-1217ad6b90f1</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>cart</td>\n      <td>1005100</td>\n      <td>2053013555631882655</td>\n      <td>electronics.smartphone</td>\n      <td>samsung</td>\n      <td>131.770004</td>\n      <td>552718105</td>\n      <td>3f781d61-4880-49b6-87f1-c76b8a672781</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>purchase</td>\n      <td>12500508</td>\n      <td>2053013556277805513</td>\n      <td>None</td>\n      <td>None</td>\n      <td>37.040001</td>\n      <td>514037703</td>\n      <td>03838da1-e669-4ddd-929f-80ed83f7655c</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>view</td>\n      <td>18000951</td>\n      <td>2053013558525952589</td>\n      <td>None</td>\n      <td>samsung</td>\n      <td>6.500000</td>\n      <td>514704543</td>\n      <td>62f805df-084f-4495-96e5-b19b30383f7b</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>view</td>\n      <td>12702956</td>\n      <td>2053013553559896355</td>\n      <td>None</td>\n      <td>nokian</td>\n      <td>49.939999</td>\n      <td>538077530</td>\n      <td>fc34faf4-5d7b-4619-956e-da5cb363d2f5</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>view</td>\n      <td>1004833</td>\n      <td>2053013555631882655</td>\n      <td>electronics.smartphone</td>\n      <td>samsung</td>\n      <td>167.029999</td>\n      <td>514872316</td>\n      <td>f98319cb-150a-4881-9f75-225efc35f283</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>view</td>\n      <td>32900155</td>\n      <td>2055156924407612189</td>\n      <td>accessories.bag</td>\n      <td>helios</td>\n      <td>21.350000</td>\n      <td>512715261</td>\n      <td>8513665f-e4d5-41aa-9874-eb81a75246e0</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>view</td>\n      <td>1307541</td>\n      <td>2053013558920217191</td>\n      <td>computers.notebook</td>\n      <td>asus</td>\n      <td>489.359985</td>\n      <td>531477761</td>\n      <td>d531ac89-dbb0-4456-9fef-dde007e3fa55</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>2019-11-30 09:44:10</td>\n      <td>view</td>\n      <td>1480682</td>\n      <td>2053013561092866779</td>\n      <td>computers.desktop</td>\n      <td>acer</td>\n      <td>371.440002</td>\n      <td>559512811</td>\n      <td>c04dbd7f-99d7-4244-9beb-b5d5a4af7e32</td>\n      <td>2019-11-30</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/plain": "            event_time event_type  product_id          category_id  \\\n0  2019-11-30 00:00:00       view     4804055  2053013554658804075   \n1  2019-11-30 00:00:00       view     1004225  2053013555631882655   \n2  2019-11-30 00:00:00       view    12703410  2053013553559896355   \n3  2019-11-30 00:00:01       view     3601438  2053013563810775923   \n4  2019-11-30 00:00:02       view     6400179  2053013554121933129   \n5  2019-11-30 00:00:02       view    18400149  2053013553912217915   \n6  2019-11-30 00:00:02       view    40900011  2127425434894205468   \n7  2019-11-30 00:00:02       view     3500093  2053013555287949705   \n8  2019-11-30 00:00:03       view     6000167  2053013560807654091   \n9  2019-11-30 00:00:03       view     1004225  2053013555631882655   \n10 2019-11-30 00:00:03       view     2900958  2053013554776244595   \n11 2019-11-30 00:00:03       view    12705001  2053013553559896355   \n12 2019-11-30 00:00:04       view    15201321  2053013553484398879   \n13 2019-11-30 00:00:04       view     1305999  2053013558920217191   \n14 2019-11-30 00:00:04       view     6700796  2053013554247762257   \n\n                      category_code      brand        price    user_id  \\\n0       electronics.audio.headphone      apple   196.270004  548106089   \n1            electronics.smartphone      apple   952.150024  579329479   \n2                              None   cordiant    47.619999  574179352   \n3         appliances.kitchen.washer       beko   215.889999  555019938   \n4          computers.components.cpu      intel   203.869995  513342746   \n5                              None       kicx   112.489998  521867315   \n6       construction.tools.painting       None    48.910000  569407672   \n7                              None       None    33.459999  553748453   \n8            auto.accessories.alarm  centurion    82.110001  547094018   \n9            electronics.smartphone      apple   952.150024  579329479   \n10     appliances.kitchen.microwave        arg    59.180000  574140756   \n11                             None   cordiant    41.959999  547095022   \n12                             None      bosch   120.699997  542501188   \n13               computers.notebook      apple  2273.419922  568658074   \n14  computers.components.videocards   gigabyte   165.229996  564208988   \n\n                            user_session  event_date  \n0   e0b70673-d26d-4c72-98e8-7c25bb8d1216  2019-11-30  \n1   e302bdd1-1f8c-4210-9920-a55036d2e8c9  2019-11-30  \n2   69e96ac7-8042-42bf-b145-40bc937dd141  2019-11-30  \n3   626534f8-eb2a-4d05-84d4-9b9d91edb9d8  2019-11-30  \n4   4ba0eec3-1026-4df4-9495-17773a86ead5  2019-11-30  \n5   824aa67e-7220-4735-9507-0f37b3d5c27b  2019-11-30  \n6   5d9b3bbd-4efc-4b7c-86dd-8cb9e2bc8f77  2019-11-30  \n7   4310c6c8-e10c-49db-a85c-051aaf0969d3  2019-11-30  \n8   cea57a4d-5343-4de2-81fc-48124020b8bf  2019-11-30  \n9   e302bdd1-1f8c-4210-9920-a55036d2e8c9  2019-11-30  \n10  a26912f8-2ee2-4579-99b1-5483bd6bb43f  2019-11-30  \n11  29e5279b-23a8-42a3-b337-e9110e4789e6  2019-11-30  \n12  78a1a976-3795-4f12-81e7-aaec699fab90  2019-11-30  \n13  4c04c422-dca3-48f0-8ae9-64653b9b4840  2019-11-30  \n14  2662d597-acb8-4adc-8951-923b1329362b  2019-11-30  ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>event_time</th>\n      <th>event_type</th>\n      <th>product_id</th>\n      <th>category_id</th>\n      <th>category_code</th>\n      <th>brand</th>\n      <th>price</th>\n      <th>user_id</th>\n      <th>user_session</th>\n      <th>event_date</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2019-11-30 00:00:00</td>\n      <td>view</td>\n      <td>4804055</td>\n      <td>2053013554658804075</td>\n      <td>electronics.audio.headphone</td>\n      <td>apple</td>\n      <td>196.270004</td>\n      <td>548106089</td>\n      <td>e0b70673-d26d-4c72-98e8-7c25bb8d1216</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2019-11-30 00:00:00</td>\n      <td>view</td>\n      <td>1004225</td>\n      <td>2053013555631882655</td>\n      <td>electronics.smartphone</td>\n      <td>apple</td>\n      <td>952.150024</td>\n      <td>579329479</td>\n      <td>e302bdd1-1f8c-4210-9920-a55036d2e8c9</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2019-11-30 00:00:00</td>\n      <td>view</td>\n      <td>12703410</td>\n      <td>2053013553559896355</td>\n      <td>None</td>\n      <td>cordiant</td>\n      <td>47.619999</td>\n      <td>574179352</td>\n      <td>69e96ac7-8042-42bf-b145-40bc937dd141</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2019-11-30 00:00:01</td>\n      <td>view</td>\n      <td>3601438</td>\n      <td>2053013563810775923</td>\n      <td>appliances.kitchen.washer</td>\n      <td>beko</td>\n      <td>215.889999</td>\n      <td>555019938</td>\n      <td>626534f8-eb2a-4d05-84d4-9b9d91edb9d8</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2019-11-30 00:00:02</td>\n      <td>view</td>\n      <td>6400179</td>\n      <td>2053013554121933129</td>\n      <td>computers.components.cpu</td>\n      <td>intel</td>\n      <td>203.869995</td>\n      <td>513342746</td>\n      <td>4ba0eec3-1026-4df4-9495-17773a86ead5</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>2019-11-30 00:00:02</td>\n      <td>view</td>\n      <td>18400149</td>\n      <td>2053013553912217915</td>\n      <td>None</td>\n      <td>kicx</td>\n      <td>112.489998</td>\n      <td>521867315</td>\n      <td>824aa67e-7220-4735-9507-0f37b3d5c27b</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>2019-11-30 00:00:02</td>\n      <td>view</td>\n      <td>40900011</td>\n      <td>2127425434894205468</td>\n      <td>construction.tools.painting</td>\n      <td>None</td>\n      <td>48.910000</td>\n      <td>569407672</td>\n      <td>5d9b3bbd-4efc-4b7c-86dd-8cb9e2bc8f77</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>2019-11-30 00:00:02</td>\n      <td>view</td>\n      <td>3500093</td>\n      <td>2053013555287949705</td>\n      <td>None</td>\n      <td>None</td>\n      <td>33.459999</td>\n      <td>553748453</td>\n      <td>4310c6c8-e10c-49db-a85c-051aaf0969d3</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>2019-11-30 00:00:03</td>\n      <td>view</td>\n      <td>6000167</td>\n      <td>2053013560807654091</td>\n      <td>auto.accessories.alarm</td>\n      <td>centurion</td>\n      <td>82.110001</td>\n      <td>547094018</td>\n      <td>cea57a4d-5343-4de2-81fc-48124020b8bf</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>2019-11-30 00:00:03</td>\n      <td>view</td>\n      <td>1004225</td>\n      <td>2053013555631882655</td>\n      <td>electronics.smartphone</td>\n      <td>apple</td>\n      <td>952.150024</td>\n      <td>579329479</td>\n      <td>e302bdd1-1f8c-4210-9920-a55036d2e8c9</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>2019-11-30 00:00:03</td>\n      <td>view</td>\n      <td>2900958</td>\n      <td>2053013554776244595</td>\n      <td>appliances.kitchen.microwave</td>\n      <td>arg</td>\n      <td>59.180000</td>\n      <td>574140756</td>\n      <td>a26912f8-2ee2-4579-99b1-5483bd6bb43f</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>2019-11-30 00:00:03</td>\n      <td>view</td>\n      <td>12705001</td>\n      <td>2053013553559896355</td>\n      <td>None</td>\n      <td>cordiant</td>\n      <td>41.959999</td>\n      <td>547095022</td>\n      <td>29e5279b-23a8-42a3-b337-e9110e4789e6</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>2019-11-30 00:00:04</td>\n      <td>view</td>\n      <td>15201321</td>\n      <td>2053013553484398879</td>\n      <td>None</td>\n      <td>bosch</td>\n      <td>120.699997</td>\n      <td>542501188</td>\n      <td>78a1a976-3795-4f12-81e7-aaec699fab90</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>2019-11-30 00:00:04</td>\n      <td>view</td>\n      <td>1305999</td>\n      <td>2053013558920217191</td>\n      <td>computers.notebook</td>\n      <td>apple</td>\n      <td>2273.419922</td>\n      <td>568658074</td>\n      <td>4c04c422-dca3-48f0-8ae9-64653b9b4840</td>\n      <td>2019-11-30</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>2019-11-30 00:00:04</td>\n      <td>view</td>\n      <td>6700796</td>\n      <td>2053013554247762257</td>\n      <td>computers.components.videocards</td>\n      <td>gigabyte</td>\n      <td>165.229996</td>\n      <td>564208988</td>\n      <td>2662d597-acb8-4adc-8951-923b1329362b</td>\n      <td>2019-11-30</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
-     "execution_count": 29,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -909,17 +1404,27 @@
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Is the Query Slow or is it Just your Laptop?\n",
-    "So far, we've created 61 transactions (the sequence number in the metadata will be 61 if you've run this notebook once). We haven't optimized the table at this point. So we are going to do that now and see if we can reduce the query time. Whether this is a local experiment or production, you'll still need to periodically \"clean\" your tables up!"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "source": [
+    "## Is the Query Slow or is it Just your Laptop?\n",
+    "These queries are super fast. But we're also not streaming yet. \n",
+    "* We haven't optimized any of the tables at this point.\n",
+    "* The next few cells show how to use the Iceberg stored procedures.  \n",
+    "* Whether this is a local experiment or production, you'll still need to periodically \"clean\" your tables up!"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 81,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:24:05.822684Z",
+     "start_time": "2025-09-27T20:24:04.015698Z"
+    }
+   },
    "outputs": [],
    "source": [
     "#result_df = spark.sql(f\"\"\"\n",
@@ -938,21 +1443,21 @@
     "result_df = spark.sql(f\"\"\"\n",
     "CALL system.expire_snapshots(\n",
     "  table => 'lakekeeper.{catalog_namespace}.{iceberg_table_name}', \n",
-    "  older_than => '2025-09-27 00:00:00'\n",
+    "  older_than => '2025-09-28 00:00:00'\n",
     ")\n",
     "\"\"\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T00:59:16.414432Z",
-     "start_time": "2025-09-27T00:59:15.536405Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 82,
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:24:08.201726Z",
+     "start_time": "2025-09-27T20:24:08.159406Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -963,37 +1468,107 @@
       " deleted_position_delete_files_count | 0   \n",
       " deleted_equality_delete_files_count | 0   \n",
       " deleted_manifest_files_count        | 0   \n",
-      " deleted_manifest_lists_count        | 0   \n",
+      " deleted_manifest_lists_count        | 60  \n",
       " deleted_statistics_files_count      | 0   \n"
      ]
     }
    ],
    "source": [
     "result_df.show(1, 0, True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'results_df' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[31m---------------------------------------------------------------------------\u001B[39m",
+      "\u001B[31mNameError\u001B[39m                                 Traceback (most recent call last)",
+      "\u001B[36mCell\u001B[39m\u001B[36m \u001B[39m\u001B[32mIn[83]\u001B[39m\u001B[32m, line 7\u001B[39m\n\u001B[32m      1\u001B[39m result_df = spark.sql(\u001B[33mf\u001B[39m\u001B[33m\"\"\"\u001B[39m\n\u001B[32m      2\u001B[39m \u001B[33mCALL system.expire_snapshots(\u001B[39m\n\u001B[32m      3\u001B[39m \u001B[33m  table => \u001B[39m\u001B[33m'\u001B[39m\u001B[33mlakekeeper.\u001B[39m\u001B[38;5;132;01m{\u001B[39;00mcatalog_namespace\u001B[38;5;132;01m}\u001B[39;00m\u001B[33m.\u001B[39m\u001B[38;5;132;01m{\u001B[39;00miceberg_table_name_hp\u001B[38;5;132;01m}\u001B[39;00m\u001B[33m'\u001B[39m\u001B[33m, \u001B[39m\n\u001B[32m      4\u001B[39m \u001B[33m  older_than => \u001B[39m\u001B[33m'\u001B[39m\u001B[33m2025-09-28 00:00:00\u001B[39m\u001B[33m'\u001B[39m\n\u001B[32m      5\u001B[39m \u001B[33m)\u001B[39m\n\u001B[32m      6\u001B[39m \u001B[33m\"\"\"\u001B[39m)\n\u001B[32m----> \u001B[39m\u001B[32m7\u001B[39m \u001B[43mresults_df\u001B[49m.show(\u001B[32m1\u001B[39m, \u001B[32m0\u001B[39m, \u001B[38;5;28;01mTrue\u001B[39;00m)\n",
+      "\u001B[31mNameError\u001B[39m: name 'results_df' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "result_df = spark.sql(f\"\"\"\n",
+    "CALL system.expire_snapshots(\n",
+    "  table => 'lakekeeper.{catalog_namespace}.{iceberg_table_name_hp}', \n",
+    "  older_than => '2025-09-28 00:00:00'\n",
+    ")\n",
+    "\"\"\")\n",
+    "result_df.show(1, 0, True)"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2025-09-27T00:59:18.777330Z",
-     "start_time": "2025-09-27T00:59:18.745930Z"
+     "end_time": "2025-09-27T20:25:10.531676Z",
+     "start_time": "2025-09-27T20:25:09.311317Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-RECORD 0----------------------------------\n",
+      " deleted_data_files_count            | 0   \n",
+      " deleted_position_delete_files_count | 0   \n",
+      " deleted_equality_delete_files_count | 0   \n",
+      " deleted_manifest_files_count        | 0   \n",
+      " deleted_manifest_lists_count        | 60  \n",
+      " deleted_statistics_files_count      | 0   \n"
+     ]
+    }
+   ],
+   "source": [
+    "result_df = spark.sql(f\"\"\"\n",
+    "CALL system.expire_snapshots(\n",
+    "  table => 'lakekeeper.{catalog_namespace}.{use_ddl_table}', \n",
+    "  older_than => '2025-09-28 00:00:00'\n",
+    ")\n",
+    "\"\"\")\n",
+    "result_df.show(1, 0, True)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-09-27T20:26:33.455888Z",
+     "start_time": "2025-09-27T20:26:32.220672Z"
     }
    }
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "## Fruits of our Labor?\n",
     "Go ahead and **run the SQL query from before we tried to optimize the table** again. You may notice we're not getting a boost in speed. So what is happening here? \n",
     "\n",
-    "This is an issue with the \"partitions\", (oh that again you say!). We can use something called \"hidden partitioning\" here to remove the \"explicit\" directories, after all we are no longer living in a Hive/Hadoop world. Rid yourself of the baggage of \"physical\" directory based partitioning. You'll thank yourself."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "The tables are actually performing really well. We don't have hundreds of gigabytes of metadata stacking up. The maintenance tasks so far are not a problem.\n",
+    "\n",
+    "* Next, we're going to move on and utilize our **Foundational Tables** as the basis for our Streaming Iceberg best practices. Follow along :) "
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 32,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-09-27T01:00:08.615422Z",
+     "start_time": "2025-09-27T01:00:08.607162Z"
+    },
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# > Note: This fails with S3 IO.\n",
@@ -1004,38 +1579,6 @@
     "#)\n",
     "#\"\"\")\n",
     "# clear_orphans_df.show(1, 0, True)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2025-09-27T01:00:08.615422Z",
-     "start_time": "2025-09-27T01:00:08.607162Z"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-09-26T23:04:19.599810Z",
-     "start_time": "2025-09-26T23:04:19.552554Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "DataFrame[]"
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# > Note: This is the nuclear option to scrap the table and all metadata and simply begin again!\n",
-    "# spark.sql(f\"DROP TABLE {catalog_namespace}.{iceberg_table_name}\")\n",
-    "#spark.sql(f\"DROP NAMESPACE {catalog_namespace}\")"
    ]
   },
   {
@@ -1043,7 +1586,11 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# > Note: This is the nuclear option to scrap the table and all metadata and simply begin again!\n",
+    "# spark.sql(f\"DROP TABLE {catalog_namespace}.{iceberg_table_name}\")\n",
+    "#spark.sql(f\"DROP NAMESPACE {catalog_namespace}\")"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
These updates are mainly to setup a great test for our streaming workflow. I was able to reliably break things when I went up to 24 CPU cores and 48GB ram on the jupyter spark driver. For "local" development was able to shave around 50% of the time off of initial write of the 109 million records, additionally, was able to shave off around 80% of the read time when using optimized tables with hidden partitions.

Next, on to streaming. Woot